### PR TITLE
Update Dockerfile to complete pip upgrade first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
 		python-dev \
 		python-pip && \
 	pip install \
-		--upgrade pip \
+		--upgrade pip && \
+	pip install \
 		python-keystoneclient \
 		python-novaclient \
 		python-heatclient \


### PR DESCRIPTION
The current Dockerfile does not allow pip to finish upgrading first before attempting to install the other packages, resulting in errors.